### PR TITLE
db migrate missing rake file

### DIFF
--- a/MAC/on_appliance/miq-setup.sh
+++ b/MAC/on_appliance/miq-setup.sh
@@ -10,6 +10,7 @@ echo
 
 # Migrate the database.
 echo "**** Migrateing the database..."
+cd /var/www/miq/vmdb/
 bin/rake db:migrate || exit 1
 echo "**** done."
 echo


### PR DESCRIPTION
Change directory before db migrate is executed.

***\* Migrateing the database...
rake aborted!
No Rakefile found (looking for: rakefile, Rakefile, rakefile.rb, Rakefile.rb)
