### PR TITLE
Create MIQROOT/vmdb/vendor/assets symlink and allow Apache to follow

### DIFF
--- a/MAC/on_appliance/defines.sh
+++ b/MAC/on_appliance/defines.sh
@@ -5,3 +5,6 @@ DEFAULTS_DIR=/etc/default
 LOCAL_METADATA_DIR=/var/www/metadata
 LOCAL_LOG_DIR=/var/www/local_log
 LOCAL_ASSETS_DIR=/var/www/local_assets
+LOCAL_VENDOR_ASSETS_DIR=/var/www/local_vendor_assets
+
+SYMLINKS_HTTP_CONF=/etc/httpd/conf.d/cfme-symlinks.conf

--- a/MAC/on_appliance/map-source.sh
+++ b/MAC/on_appliance/map-source.sh
@@ -63,14 +63,4 @@ ln -f -s $LOCAL_ASSETS_DIR $MIQ_DIR/public/assets
 [[ -d $MIQ_DIR/vendor/assets && ! -L $MIQ_DIR/vendor/assets ]] && rm -rf $MIQ_DIR/vendor/assets
 ln -f -s $LOCAL_VENDOR_ASSETS_DIR $MIQ_DIR/vendor/assets
 
-# Allow Apache to follow the symbolic link created above and set selinux accordingly
-if [[ ! -f $SYMLINKS_HTTP_CONF ]]
-then
-  cat << CONF_END > $SYMLINKS_HTTP_CONF
-<Directory "/var/www/miq">
-  Options FollowSymLinks
-</Directory>
-CONF_END
-  /usr/bin/chcon --reference=/etc/httpd/conf/httpd.conf $SYMLINKS_HTTP_CONF
-fi
 exit 0

--- a/MAC/on_appliance/map-source.sh
+++ b/MAC/on_appliance/map-source.sh
@@ -58,4 +58,19 @@ echo "**** Run: git update-index --assume-unchanged log/.gitkeep on MAC."
 [[ -d $MIQ_DIR/public/assets && ! -L $MIQ_DIR/public/assets ]] && rm -rf $MIQ_DIR/public/assets
 ln -f -s $LOCAL_ASSETS_DIR $MIQ_DIR/public/assets
 
+# We don't want compiled assets written to our source tree.
+[[ -d $LOCAL_VENDOR_ASSETS_DIR ]] || mkdir -p $LOCAL_VENDOR_ASSETS_DIR
+[[ -d $MIQ_DIR/vendor/assets && ! -L $MIQ_DIR/vendor/assets ]] && rm -rf $MIQ_DIR/vendor/assets
+ln -f -s $LOCAL_VENDOR_ASSETS_DIR $MIQ_DIR/vendor/assets
+
+# Allow Apache to follow the symbolic link created above and set selinux accordingly
+if [[ ! -f $SYMLINKS_HTTP_CONF ]]
+then
+  cat << CONF_END > $SYMLINKS_HTTP_CONF
+<Directory "/var/www/miq">
+  Options FollowSymLinks
+</Directory>
+CONF_END
+  /usr/bin/chcon --reference=/etc/httpd/conf/httpd.conf $SYMLINKS_HTTP_CONF
+fi
 exit 0

--- a/MAC/on_appliance/software-install.sh
+++ b/MAC/on_appliance/software-install.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+. $SCRIPT_DIR/defines.sh
 PACKAGES=$(cat <<-END_PACKAGES
 		fuse
 	END_PACKAGES
@@ -19,6 +20,17 @@ then
 		sed -e "s/SELINUX=enforcing/SELINUX=permissive/" < config.sav > config
 		echo "**** done."
 	fi
+fi
+
+# Allow Apache to follow the symbolic link created above and set selinux accordingly
+if [[ ! -f $SYMLINKS_HTTP_CONF ]]
+then
+  cat << CONF_END > $SYMLINKS_HTTP_CONF
+<Directory "/var/www/miq">
+  Options FollowSymLinks
+</Directory>
+CONF_END
+  /usr/bin/chcon --reference=/etc/httpd/conf/httpd.conf $SYMLINKS_HTTP_CONF
 fi
 
 # Install the required software packages.

--- a/MAC/on_appliance/source-updated.sh
+++ b/MAC/on_appliance/source-updated.sh
@@ -27,6 +27,11 @@ echo "**** Run: git update-index --assume-unchanged log/.gitkeep on MAC."
 [[ -d $MIQ_DIR/public/assets && ! -L $MIQ_DIR/public/assets ]] && rm -rf $MIQ_DIR/public/assets
 ln -f -s $LOCAL_ASSETS_DIR $MIQ_DIR/public/assets
 
+# We don't want compiled assets written to our source tree.
+[[ -d $LOCAL_VENDOR_ASSETS_DIR ]] || mkdir -p $LOCAL_VENDOR_ASSETS_DIR
+[[ -d $MIQ_DIR/vendor/assets && ! -L $MIQ_DIR/vendor/assets ]] && rm -rf $MIQ_DIR/vendor/assets
+ln -f -s $LOCAL_VENDOR_ASSETS_DIR $MIQ_DIR/vendor/assets
+
 $SCRIPT_DIR/miq-setup.sh
 
 exit 0


### PR DESCRIPTION
the vmdb/vendor/assets directory is used to store compiled assets for the UI.
bin/update via the bower command tries to change ownership on some of these
files but while running from mapped source this will fail.
Create a symlink to the local appliance running on the VM under one's MAC
so the assets are stored locally.

In addition add to the Apache configuration so that symbolic links are followed
properly at all levels.

@roliveri @bdunne @Fryguy please review.  Merge when possible.  Thanks.
